### PR TITLE
Get Log's service URL from console line

### DIFF
--- a/agent-osx/external/LogsProxy.py
+++ b/agent-osx/external/LogsProxy.py
@@ -7,7 +7,7 @@ from LogRequest import LogRequest
 class LogsProxy(object):
     # FIXME Change Base service URL
     def __init__(self, config, url):
-        self.SERVICE_URL = url
+        self.SERVICE_URL = url + config['agentId']
         self.PRIVATE_KEY = config['privateKey']
         self.SECRET_KEY = config['secretKey']
         self.PUBLIC_KEY = config['publicKey']

--- a/agent-osx/main.py
+++ b/agent-osx/main.py
@@ -13,7 +13,7 @@ if __name__ == "__main__":
     try:
         service_url = sys.argv[1]
     except IndexError:
-        service_url = 'http://localhost:9091/api/logs'
+        service_url = 'http://localhost:9091/api/logs/agent/'
 
     print service_url
 


### PR DESCRIPTION
### Summary:

- Improved `OSX Agent` to be able to get **Logs Service URL** from **console line**
- Added `agent id` on **base service URL**