### PR TITLE
Fix Log response relationships

### DIFF
--- a/siem/service/src/main/java/bsep/sw/hateoas/log/LogResponseRelationships.java
+++ b/siem/service/src/main/java/bsep/sw/hateoas/log/LogResponseRelationships.java
@@ -5,23 +5,33 @@ import bsep.sw.hateoas.relationships.RelationshipData;
 import bsep.sw.hateoas.relationships.RelationshipLinks;
 import bsep.sw.hateoas.relationships.ResponseRelationship;
 
+import static bsep.sw.hateoas.ResourceTypes.AGENT_TYPE;
 import static bsep.sw.hateoas.ResourceTypes.PROJECTS_TYPE;
 
 public class LogResponseRelationships {
 
     public ResponseRelationship project;
+    public ResponseRelationship agent;
 
     public static LogResponseRelationships fromDomain(final Log log) {
-        final RelationshipData data = new RelationshipData(PROJECTS_TYPE, log.getProject().toString());
-        // FIXME
-        final RelationshipLinks links = new RelationshipLinks( "related-link");
+        final RelationshipData projectData = new RelationshipData(PROJECTS_TYPE, log.getProject().toString());
+        final RelationshipLinks projectLinks = new RelationshipLinks(String.format("/api/project/%d", log.getProject()));
+
+        final RelationshipData agentData = new RelationshipData(AGENT_TYPE, log.getAgent().toString());
+        final RelationshipLinks agentLinks = new RelationshipLinks(String.format("/api/project/%d/agents/%d", log.getProject(), log.getAgent()));
 
         return new LogResponseRelationships()
-                .project(new ResponseRelationship(links, data));
+                .project(new ResponseRelationship(projectLinks, projectData))
+                .agent(new ResponseRelationship(agentLinks, agentData));
     }
 
     public LogResponseRelationships project(final ResponseRelationship project) {
         this.project = project;
+        return this;
+    }
+
+    public LogResponseRelationships agent(final ResponseRelationship agent) {
+        this.agent = agent;
         return this;
     }
 


### PR DESCRIPTION
### Summary:

- Provided **agent** field in `LogResponseRelationships`.
- Added missing `related` fileds both for **agent** and **project** fields.

Closes #30 with this PR. 